### PR TITLE
Frontend.yml should only ignore TS6192 | TS6133

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,7 +29,7 @@ jobs:
           npm install --save-dev @types/node
       
       - name: TypeScript check (informational only)
-        run: npx tsc --noEmit || echo "TypeScript check completed with errors - continuing"
+        run: npx tsc --noEmit 2>&1 | grep -v -E "error TS6192|error TS6133" || echo "TypeScript check completed with errors - continuing"
       
       - name: Modified build for CI
         run: |


### PR DESCRIPTION
Frontend.yml only ignores:
1) error TS6192: All imports in import declaration are unused.
2) error TS6133: ‘X' is declared but its value is never read.