### PR TITLE
Fix docker-compose to pull from .env only + other fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Server Configuration
 PORT=8080
+CLERK_SECRET_KEY="xxxxxxxxx"
 
 # Database Configuration
 POSTGRES_USER=appuser
@@ -12,3 +13,6 @@ FRONTEND_PORT=5173
 
 # Application Environment
 ENV=development
+# development: Enable debug logging, use local database, hot reload.
+# staging: Connect to a staging database, test integrations.
+# production: Disable debug logging, use optimized settings.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 WORKDIR /app
 

--- a/backend/server.go
+++ b/backend/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
-	"github.com/joho/godotenv"
 )
 
 type Item struct {
@@ -64,10 +63,10 @@ func PutItemHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 
-	// Load .env file
-	if err := godotenv.Load(); err != nil {
-		log.Println("Warning: No .env file found")
-	}
+	// // Load .env file
+	// if err := godotenv.Load(); err != nil {
+	// 	log.Println("Warning: No .env file found")
+	// }
 
 	// Get the secret key from the environment variable
 	clerkSecretKey := os.Getenv("CLERK_SECRET_KEY")
@@ -227,18 +226,19 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(resource)
-	})	
-	// End of Clerk Routes	
+	})
+	// End of Clerk Routes
 
 	// Server config
+	port := os.Getenv("PORT")
 	server := &http.Server{
-		Addr:    ":3069",
+		Addr:    ":" + port,
 		Handler: r,
 	}
 
 	// Start server
 	go func() {
-		log.Println("Server is running on port 3069....")
+		log.Printf("Server is running on port %s....\n", port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server error: %v", err)
 		}
@@ -254,4 +254,5 @@ func main() {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Fatalf("server shutdown failed: %v", err)
 	}
+
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,6 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     environment:
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_USER=${POSTGRES_USER:-appuser}
-      - DB_PASSWORD=${POSTGRES_PASSWORD:-apppassword}
-      - DB_NAME=${POSTGRES_DB:-appdb}
-      - PORT=${PORT:-8080}
       - ENV=${ENV:-development}
     ports:
       - "${PORT:-8080}:${PORT:-8080}"
@@ -36,8 +30,8 @@ services:
     # depends_on:
     #   postgres:
     #     condition: service_healthy
-    # volumes:
-    #   - ./backend:/app
+    env_file:
+      - .env  # Load .env file
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/internal/db/schema/tenant.sql:/docker-entrypoint-initdb.d/01-schema.sql
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-appuser}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+    # healthcheck:
+    #   test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-appuser}"]
+    #   interval: 5s
+    #   timeout: 5s
+    #   retries: 5
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       - /app/node_modules
     networks:
       - app-network
+    env_file:
+      - .env  # Load .env file
 
 networks:
   app-network:

--- a/frontend/app/src/components/AdminLeasesTable.tsx
+++ b/frontend/app/src/components/AdminLeasesTable.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Table, Button } from "antd";
+import type { TableColumnsType } from "antd";
+import AntDesignTableComponent from "../components/AntDesignTableComponent";
+
+interface DataType {
+    key: React.Key;
+    name: string;
+    age: number;
+    address: string;
+}
+
+const columns: TableColumnsType<DataType> = [
+    {
+        title: "Name",
+        dataIndex: "name",
+    },
+    {
+        title: "Age",
+        dataIndex: "age",
+        sorter: (a, b) => a.age - b.age,
+    },
+    {
+        title: "Address",
+        dataIndex: "address",
+    },
+    {
+        title: "Actions",
+        key: "actions",
+        render: (_, record) => (
+            <>
+                <Button type="link" onClick={() => console.log("Edit", record)}>Edit</Button>
+                <Button type="link" danger onClick={() => console.log("Delete", record)}>Delete</Button>
+            </>
+        ),
+    },
+];
+
+const AdminLeasesTable: React.FC = () => (
+    <Table columns={columns} dataSource={AntDesignTableComponent.defaultProps?.dataSource} />
+);
+
+export default AdminLeasesTable;

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -27,6 +27,7 @@ import LoginForm from "./pages/LoginForm.tsx";
 // Clerk
 import { ClerkProvider } from "@clerk/react-router";
 import TestGoBackend from "./components/TestGoBackend.tsx";
+import AdminViewEditLeases from "./pages/AdminViewEditLeases.tsx";
 
 const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
@@ -107,7 +108,7 @@ createRoot(document.getElementById("root")!).render(
                   <Route path="add-tenant" element={<h1>Add Tenant</h1>} />
                   <Route
                     path="admin-view-and-edit-leases"
-                    element={<h1>Admin View & Edit Leases</h1>}
+                    element={<AdminViewEditLeases />}
                   />
                   <Route
                     path="admin-view-and-edit-work-orders-and-complaints"

--- a/frontend/app/src/pages/AdminViewEditLeases.tsx
+++ b/frontend/app/src/pages/AdminViewEditLeases.tsx
@@ -1,0 +1,31 @@
+import "../styles/styles.scss";
+import {
+    ArrowLeftOutlined,
+} from "@ant-design/icons";
+import { useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import {
+    Avatar,
+    Button,
+    Card,
+    Col,
+    ConfigProvider,
+    Divider,
+    Input,
+    Row,
+} from "antd"
+import AntDesignTableComponent from "../components/AntDesignTableComponent"
+
+export default function AdminViewEditLeases() {
+
+
+    return (
+        <div>
+            <h1>Admin View & Edit Leases</h1>
+            <div className="table m-5">
+                <h2>Table</h2>
+                <AntDesignTableComponent />
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/src/styles/styles.scss
+++ b/frontend/app/src/styles/styles.scss
@@ -123,3 +123,7 @@ body {
 .table {
   background: $secondary5;
 }
+
+$sass-options: (
+  enable-deprecation-warnings: false
+);


### PR DESCRIPTION
- In backend/Dockerfile:
Changed image to FROM golang:1.23-alpine
- In docker-compose.yml backend service:
-- -- Added:
env_file:
      - .env  # Load .env file
-- Removed all db vars and relying on .env
-- Removed this because we are using air for live reload

# volumes:
#   - ./backend:/app

- In server.go:
-- pulling server port from .env instead of hardcoding