### PR TITLE
DSD 104 fix docker compose to pull from env only and other fixes FINAL ATTEMPT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Server Configuration
 PORT=8080
+CLERK_SECRET_KEY="xxxxxxxxx"
 
 # Database Configuration
 POSTGRES_USER=appuser
@@ -12,3 +13,6 @@ FRONTEND_PORT=5173
 
 # Application Environment
 ENV=development
+# development: Enable debug logging, use local database, hot reload.
+# staging: Connect to a staging database, test integrations.
+# production: Disable debug logging, use optimized settings.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 WORKDIR /app
 

--- a/backend/server.go
+++ b/backend/server.go
@@ -64,7 +64,7 @@ func PutItemHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 
-	// Load .env file
+	// // Load .env file
 	if err := godotenv.Load(); err != nil {
 		log.Println("Warning: No .env file found")
 	}
@@ -227,18 +227,19 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(resource)
-	})	
-	// End of Clerk Routes	
+	})
+	// End of Clerk Routes
 
 	// Server config
+	port := os.Getenv("PORT")
 	server := &http.Server{
-		Addr:    ":3069",
+		Addr:    ":" + port,
 		Handler: r,
 	}
 
 	// Start server
 	go func() {
-		log.Println("Server is running on port 3069....")
+		log.Printf("Server is running on port %s....\n", port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server error: %v", err)
 		}
@@ -254,4 +255,5 @@ func main() {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Fatalf("server shutdown failed: %v", err)
 	}
+
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/internal/db/schema/tenant.sql:/docker-entrypoint-initdb.d/01-schema.sql
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-appuser}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+    # healthcheck:
+    #   test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-appuser}"]
+    #   interval: 5s
+    #   timeout: 5s
+    #   retries: 5
     networks:
       - app-network
 
@@ -23,12 +23,6 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     environment:
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_USER=${POSTGRES_USER:-appuser}
-      - DB_PASSWORD=${POSTGRES_PASSWORD:-apppassword}
-      - DB_NAME=${POSTGRES_DB:-appdb}
-      - PORT=${PORT:-8080}
       - ENV=${ENV:-development}
     ports:
       - "${PORT:-8080}:${PORT:-8080}"
@@ -36,8 +30,8 @@ services:
     # depends_on:
     #   postgres:
     #     condition: service_healthy
-    # volumes:
-    #   - ./backend:/app
+    env_file:
+      - .env  # Load .env file
     networks:
       - app-network
 
@@ -52,6 +46,8 @@ services:
       - /app/node_modules
     networks:
       - app-network
+    env_file:
+      - .env  # Load .env file
 
 networks:
   app-network:


### PR DESCRIPTION
- In backend/Dockerfile: Changed image to FROM golang:1.23-alpine
- In docker-compose.yml backend service:
-- Added:
```yaml
env_file:
      - .env  # Load .env file
 ```
-- Removed all db vars and relying on .env
-- Removed this because we are using air for live reload
```yaml 
# volumes:
#   - ./backend:/app
```
-- in frontend service: Need to load .env file to frontend as well in docker-compose
-- commented out DB healthcheck from docker-compose.yml
- In server.go:
-- pulling server port from .env instead of hardcoding
- changed .env.example